### PR TITLE
`Fix inline HeaderMotion.Header overlay stacking above scrollables`

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -83,6 +83,7 @@ const headerOverlayStyle = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
+    zIndex: 10,
   },
 }).overlay;
 

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -95,6 +95,7 @@ const headerOverlayStyle = {
   top: 0,
   left: 0,
   right: 0,
+  zIndex: 10,
 };
 
 describe('Header components', () => {


### PR DESCRIPTION

Fixes #22

## Problem
Inline header mode (without `NavigationBridge`) can render behind scrollables because the overlay header has no explicit stacking order.

## Fix
- Add `zIndex: 10` to `HeaderMotion.Header` overlay style in `src/components/Header.tsx`.
- Update `src/components/__tests__/Header.test.tsx` overlay style expectation.

## Scope
This is a minimal visual stacking fix for inline-header setups and does not modify scroll manager logic.

## Validation
- Updated header tests pass.
- Full test suite passes locally (`8/8` suites, `38/38` tests).

