### PR TITLE
feat: support react-native-gesture-handler v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,48 @@ jobs:
       - name: Run unit tests
         run: yarn test --maxWorkers=2 --coverage
 
+  # Enforces the `react-native-gesture-handler: ^2.0.0 || ^3.0.0` peer range.
+  #
+  # `yarn typecheck` is the load-bearing step: `src/` is `.ts`, so `skipLibCheck`
+  # does NOT suppress a missing Gesture Handler export there, and the imports in
+  # our shipped `.d.ts` are generated from those same statements. A consumer-side
+  # type test cannot replace this — in a `.d.ts`, an unresolved import silently
+  # widens to the error type instead of failing, which no type assertion can
+  # detect.
+  #
+  # Majors are tracked by tag rather than pinned so an upstream release that
+  # breaks the range surfaces here instead of in users' projects.
+  gesture-handler-compat:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        gesture-handler: ['2', '3']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Install Gesture Handler v${{ matrix.gesture-handler }}
+        # Overriding the pinned devDependency necessarily mutates package.json
+        # and yarn.lock, which CI's default immutable install forbids.
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
+        run: yarn add -D react-native-gesture-handler@${{ matrix.gesture-handler }}
+
+      - name: Report resolved version
+        run: node -p "require('react-native-gesture-handler/package.json').version"
+
+      - name: Typecheck files
+        run: yarn typecheck
+
+      - name: Run unit tests
+        run: yarn test --maxWorkers=2
+
   build-library:
     runs-on: ubuntu-latest
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -46,16 +46,23 @@ bun add react-native-header-motion
 
 Header Motion relies on three peer dependencies that your project must provide:
 
-| Package                        | Required version |
-| ------------------------------ | ---------------- |
-| `react-native-reanimated`      | `^4.0.0`         |
-| `react-native-gesture-handler` | `^2.0.0`         |
-| `react-native-worklets`        | `>= 0.4.0`       |
+| Package                        | Required version     |
+| ------------------------------ | -------------------- |
+| `react-native-reanimated`      | `^4.0.0`             |
+| `react-native-gesture-handler` | `^2.0.0 \|\| ^3.0.0` |
+| `react-native-worklets`        | `>= 0.4.0`           |
 
 If you already have these installed, you're good to go. Otherwise, follow their respective installation guides:
 
 - [Reanimated & Worklets installation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#installation)
 - [Gesture Handler installation](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation)
+
+:::info
+Both Gesture Handler v2 and v3 are supported, and no configuration is needed to
+pick between them. Header Motion uses the gesture API that v3 keeps at the
+package root, and v3's `GestureDetector` transparently handles it — so the same
+code runs on either major.
+:::
 
 :::caution
 Make sure the version of `react-native-worklets` you install is compatible with your version of Reanimated. Check the [compatibility table](https://docs.swmansion.com/react-native-reanimated/docs/guides/compatibility) before installing.

--- a/docs/docs/other/faq.md
+++ b/docs/docs/other/faq.md
@@ -20,6 +20,14 @@ If your header lives inside the same component tree as `HeaderMotion` (not rende
 
 Header panning is built on Gesture Handler's pan gesture. Even if you don't use the `pannable` prop, the library imports from `react-native-gesture-handler`. Most React Native projects already have it installed.
 
+## Does Header Motion work with Gesture Handler v3?
+
+Yes. Both v2 and v3 are supported by the same build — there's no separate entry point, flag, or configuration to set.
+
+Header Motion touches a deliberately small part of Gesture Handler: the `Gesture` builder, `GestureDetector`, `GestureHandlerRootView`, and the `GestureStateChangeEvent` / `PanGestureHandlerEventPayload` types. v3 still exports all of these from the package root under the same names, and its `GestureDetector` accepts gestures from either API and routes them accordingly. The v3 rename that moved parts of the v2 surface behind `Legacy*` names affected components and gesture instance types that this library doesn't use.
+
+One consequence worth knowing if you compile with `skipLibCheck: false`: Gesture Handler v3 currently ships a native component spec whose props don't structurally extend React Native's `ViewProps`, so that setting fails inside `react-native-gesture-handler` itself, independently of Header Motion. `skipLibCheck: true` — the React Native template default — is the supported configuration.
+
 ## Can I use this with FlashList / LegendList / other custom scrollables?
 
 Yes. Use `createHeaderMotionScrollable()` to wrap any scrollable component. For FlashList and LegendList, you can also use the built-in `ScrollablePresets` export so the recommended factory options are already filled in. See the [Custom scrollables](../guides/custom-scrollables) guide.

--- a/docs/docs/other/migration-from-v0.md
+++ b/docs/docs/other/migration-from-v0.md
@@ -36,11 +36,11 @@ The biggest shift is from a **prop-passing header API** to a **context-first hea
 
 v1 requires:
 
-| Package                        | Version    |
-| ------------------------------ | ---------- |
-| `react-native-gesture-handler` | `^2.0.0`   |
-| `react-native-reanimated`      | `^4.0.0`   |
-| `react-native-worklets`        | `>= 0.4.0` |
+| Package                        | Version              |
+| ------------------------------ | -------------------- |
+| `react-native-gesture-handler` | `^2.0.0 \|\| ^3.0.0` |
+| `react-native-reanimated`      | `^4.0.0`             |
+| `react-native-worklets`        | `>= 0.4.0`           |
 
 `react-native-gesture-handler` is new to the peer surface because header panning is built on it.
 

--- a/example/package.json
+++ b/example/package.json
@@ -21,7 +21,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.2",
-    "react-native-gesture-handler": "2.30.0",
+    "react-native-gesture-handler": "3.2.1",
     "react-native-pager-view": "8.0.0",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react": "19.2.0",
     "react-native": "0.83.2",
     "react-native-builder-bob": "^0.40.17",
-    "react-native-gesture-handler": "2.30.0",
+    "react-native-gesture-handler": "3.2.1",
     "react-native-reanimated": "4.2.1",
     "react-native-worklets": "0.7.2",
     "release-it": "^19.0.4",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-gesture-handler": "^2.0.0",
+    "react-native-gesture-handler": "^2.0.0 || ^3.0.0",
     "react-native-reanimated": "^4.0.0",
     "react-native-worklets": ">=0.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3355,15 +3355,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@egjs/hammerjs@npm:^2.0.17":
-  version: 2.0.17
-  resolution: "@egjs/hammerjs@npm:2.0.17"
-  dependencies:
-    "@types/hammerjs": "npm:^2.0.36"
-  checksum: 10c0/dbedc15a0e633f887c08394bd636faf6a3abd05726dc0909a0e01209d5860a752d9eca5e512da623aecfabe665f49f1d035de3103eb2f9022c5cea692f9cc9be
-  languageName: node
-  linkType: hard
-
 "@eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.1":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
@@ -6645,13 +6636,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/hammerjs@npm:^2.0.36":
-  version: 2.0.46
-  resolution: "@types/hammerjs@npm:2.0.46"
-  checksum: 10c0/f3c1cb20dc2f0523f7b8c76065078544d50d8ae9b0edc1f62fed657210ed814266ff2dfa835d2c157a075991001eec3b64c88bf92e3e6e895c0db78d05711d06
-  languageName: node
-  linkType: hard
-
 "@types/hast@npm:^3.0.0":
   version: 3.0.4
   resolution: "@types/hast@npm:3.0.4"
@@ -6850,6 +6834,15 @@ __metadata:
     "@types/history": "npm:^4.7.11"
     "@types/react": "npm:*"
   checksum: 10c0/1f7eee61981d2f807fa01a34a0ef98ebc0774023832b6611a69c7f28fdff01de5a38cabf399f32e376bf8099dcb7afaf724775bea9d38870224492bea4cb5737
+  languageName: node
+  linkType: hard
+
+"@types/react-test-renderer@npm:^19.1.0":
+  version: 19.1.0
+  resolution: "@types/react-test-renderer@npm:19.1.0"
+  dependencies:
+    "@types/react": "npm:*"
+  checksum: 10c0/799654e430df10aeaf267d71507fb64ec151359ead7e3774111bfd4abce7e0911dba461811195c06c22a6d17496ea92537d3185320ff4112fe29954cad1b9152
   languageName: node
   linkType: hard
 
@@ -12787,7 +12780,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.0":
+"hoist-non-react-statics@npm:^3.1.0":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -19290,17 +19283,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-gesture-handler@npm:2.30.0":
-  version: 2.30.0
-  resolution: "react-native-gesture-handler@npm:2.30.0"
+"react-native-gesture-handler@npm:3.2.1":
+  version: 3.2.1
+  resolution: "react-native-gesture-handler@npm:3.2.1"
   dependencies:
-    "@egjs/hammerjs": "npm:^2.0.17"
-    hoist-non-react-statics: "npm:^3.3.0"
+    "@types/react-test-renderer": "npm:^19.1.0"
     invariant: "npm:^2.2.4"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/26b94b0f97433fc6fb5b1c196ef29fce4f5a66c77fabb1bc33db91099357fbd44a5220783fcbb91d42700bcd578f2fd114314029d9e0d4674878767d9b7f5df6
+  checksum: 10c0/e20537d1eafe35206494eae7885ef85e7cd85185b32ccaac3d25f3e87beafa007ac79556c0af8da245db1140f6b5df35d20509d7fa56301d730de5a8abb1b90f
   languageName: node
   linkType: hard
 
@@ -19321,7 +19313,7 @@ __metadata:
     react-dom: "npm:19.2.0"
     react-native: "npm:0.83.2"
     react-native-builder-bob: "npm:^0.40.17"
-    react-native-gesture-handler: "npm:2.30.0"
+    react-native-gesture-handler: "npm:3.2.1"
     react-native-monorepo-config: "npm:^0.3.1"
     react-native-pager-view: "npm:8.0.0"
     react-native-reanimated: "npm:4.2.1"
@@ -19356,7 +19348,7 @@ __metadata:
     react: "npm:19.2.0"
     react-native: "npm:0.83.2"
     react-native-builder-bob: "npm:^0.40.17"
-    react-native-gesture-handler: "npm:2.30.0"
+    react-native-gesture-handler: "npm:3.2.1"
     react-native-reanimated: "npm:4.2.1"
     react-native-worklets: "npm:0.7.2"
     release-it: "npm:^19.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19364,7 +19364,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-gesture-handler: ^2.0.0
+    react-native-gesture-handler: ^2.0.0 || ^3.0.0
     react-native-reanimated: ^4.0.0
     react-native-worklets: ">=0.4.0"
   languageName: unknown


### PR DESCRIPTION
## Purpose

This change adds support for `react-native-gesture-handler` v3. The library
continues to support v2. The peer range becomes `^2.0.0 || ^3.0.0`.

No source code changes are necessary. The reasons are below.

## Why the source code does not change

The library uses five symbols from Gesture Handler:

| Symbol | Kind | Location |
| --- | --- | --- |
| `Gesture` | value | `HeaderPanBoundary.tsx` |
| `GestureDetector` | value | `HeaderPanBoundary.tsx` |
| `GestureHandlerRootView` | value | `HeaderPanBoundary.tsx` |
| `GestureStateChangeEvent` | type | `types.ts` |
| `PanGestureHandlerEventPayload` | type | `types.ts` |

v3 exports all five symbols from the package root. The names do not change.
The payload types keep the same shape.

v3 changes `GestureDetector`. The root export is now the v3 detector. This
detector accepts a gesture from either API. It sends a legacy gesture to the
legacy detector:

```js
if (props.gesture instanceof ComposedGesture || props.gesture instanceof BaseGesture) {
  return <LegacyGestureDetector {...props} />;
}
return <NativeDetector {...props} />;
```

v3 also renames part of the v2 surface to `Legacy*` names. These renames apply
to components and to gesture instance types. The library does not import these
items.

The library keeps the legacy gesture API. Do not migrate to the v3
`usePanGesture` hook. A migration makes version-conditional code necessary.

## How CI enforces the peer range

This change adds a `gesture-handler-compat` job. The job runs a matrix over
both majors. Each leg installs one major. Then each leg runs `yarn typecheck`
and `yarn test`.

`yarn typecheck` is the important step. `src/` holds `.ts` files.
Therefore `skipLibCheck` does not hide a missing Gesture Handler export.
The shipped `.d.ts` imports come from the same statements in `src/`.

The matrix tracks each major by tag. It does not pin a patch version. An
upstream release that breaks the range then fails in CI. Users do not find the
failure first.

## A consumer type test is not possible

I built a consumer-side type test. Then I removed it. The test cannot fail
when it must fail.

An unresolved import inside a `.d.ts` becomes the TypeScript error type.
TypeScript hides subsequent errors from the error type. Therefore no assertion
detects the problem. This includes `0 extends 1 & T` detection of `any`.

I confirmed this behaviour. I pointed the built `types.d.ts` at an export that
does not exist. The test still passed.

The same break in `src/types.ts` gives a clear failure:

```
error TS2305: Module '"react-native-gesture-handler"' has no exported member ...
```

For this reason, `yarn typecheck` is the guarantee. The workflow file records
this reason. Do not add the fixture again.

## `skipLibCheck: false` is not possible with v3

v3 ships `specs/RNGestureHandlerDetectorNativeComponent.d.ts`. Its
`NativeProps` does not extend the React Native `ViewProps` type. This gives
error `TS2430` inside `react-native-gesture-handler`.

This problem is independent of Header Motion. No change in this repository can
correct it. Therefore `skipLibCheck: true` is the supported configuration. This
value is also the React Native template default.

The FAQ records this limit.

## Development versions

The pinned devDependency moves to 3.2.1. The example app also moves to 3.2.1.
Local development then uses the v3 code path.

The example app is important here. Unit tests replace Gesture Handler with a
mock. Therefore the tests do not run the `LegacyGestureDetector` branch. The
example app is the only place that runs this branch.

The v2 leg of the matrix stays correct. That leg overrides only the root
devDependency. `yarn typecheck` excludes `example`. Jest ignores
`example/node_modules`. I simulated this install. The root resolved v2.
`yarn typecheck` and `yarn test` passed.

## Verification

I ran these commands against 2.30.0, 2.32.0, and 3.2.1:

- `yarn lint` — pass. Two warnings exist in `docs/`. They are not new.
- `yarn typecheck` — pass.
- `yarn test` — pass. 38 tests.
- `yarn prepare` — pass.
- `npx tsc --noEmit` in `example/` — pass.

## Open item

No test runs v3 on a device. Please run the example app and use a pannable
header. This action exercises the `LegacyGestureDetector` branch at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
